### PR TITLE
Map search bar, map scale indicator

### DIFF
--- a/django/world/python_scripts/parse_coordinates_hypsometric.py
+++ b/django/world/python_scripts/parse_coordinates_hypsometric.py
@@ -25,7 +25,6 @@ def parse_coordinates_hypsometric(request):
     if not valid:
         return request_result
 
-    print(request_result)
     coordinates = request_result['features'][0]['geometry']['coordinates'][0]
     pk_of_the_image = gen_hypso_map(coordinates[0][0], coordinates[0][1], coordinates[2][0], coordinates[2][1],
                                     request_result['smooth_color'])

--- a/django/world/static/map.js
+++ b/django/world/static/map.js
@@ -2,6 +2,44 @@ const attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">Op
 const map = L.map('map').setView([50.2858, 20.78682], 5);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {attribution: attribution}).addTo(map);
 
+L.control.scale().addTo(map);
+
+const provider = new GeoSearch.EsriProvider();
+// const provider = new GeoSearch.OpenStreetMapProvider();
+
+const searchControl = new GeoSearch.GeoSearchControl({
+    provider: provider,
+    style: 'bar',
+    // howMarker: true, // optional: true|false  - default true
+    // showPopup: false, // optional: true|false  - default false
+    // marker: {
+    //     // optional: L.Marker    - default L.Icon.Default
+    //     icon: new L.Icon.Default(),
+    //     draggable: false,
+    // },
+    // popupFormat: ({query, result}) => result.label, // optional: function    - default returns result label,
+    // resultFormat: ({result}) => result.label, // optional: function    - default returns result label
+    // maxMarkers: 1, // optional: number      - default 1
+    // retainZoomLevel: false, // optional: true|false  - default false
+    // animateZoom: true, // optional: true|false  - default true
+    // autoClose: false, // optional: true|false  - default false
+    // searchLabel: 'Enter address', // optional: string      - default 'Enter address'
+    // keepResult: false, // optional: true|false  - default false
+    // updateMap: true, // optional: true|false  - default true
+});
+
+
+map.addControl(searchControl);
+
+map.on('click', function (e) {
+    map.dragging.enable();
+    map.touchZoom.enable();
+    map.doubleClickZoom.enable();
+    map.scrollWheelZoom.enable();
+    map.boxZoom.enable();
+    map.keyboard.enable();
+});
+
 var featureGroup = L.featureGroup().addTo(map);
 
 var drawControl = new L.Control.Draw({
@@ -15,6 +53,7 @@ map.on('draw:created', function (e) {
     // Each time a feature is created, it's added to the over arching feature group
     featureGroup.addLayer(e.layer);
 });
+
 
 function clear_regions() {
     featureGroup.clearLayers();
@@ -40,8 +79,7 @@ function send_data() {
             // console.log(json);
             if (data === "No region selected") {
                 $("#modalCBody").html("Nie wybrano żadnego obszaru");
-            }
-            else {
+            } else {
                 $("#modalCBody").html(data);
             }
             $(".modal-title").html("Współrzędne");

--- a/django/world/templates/map.html
+++ b/django/world/templates/map.html
@@ -5,15 +5,18 @@
 <head>
     <title>Mapa</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <link rel="stylesheet" href="https://d19vzq90twjlae.cloudfront.net/leaflet-0.7/leaflet.css"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css"/>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+
+    <link rel="stylesheet" href="https://unpkg.com/leaflet-geosearch@3.0.5/dist/geosearch.css"/>
+
     <link rel="stylesheet" type="text/css" href="{% static 'map.css' %}">
 </head>
 
 <body>
-
 <nav class="navbar navbar-expand-sm bg-dark navbar-dark d-flex justify-content-between align-items-center"
      style="height: 8%; min-height: 50px;">
     <a class="navbar-brand" href="#">Mały Geograf</a>
@@ -34,7 +37,6 @@
     </div>
 </nav>
 
-
 <div class="d-flex" style="height: 92% !important;">
     <div class="flex-grow-0">
         <div class="m-2 btn-group-vertical">
@@ -43,14 +45,13 @@
             <button type="button" class="btn btn-success" onclick="display_3D()">Mapa 3D</button>
             -->
             <div><input id="smooth" name="smooth" type="checkbox"/> <label for="smooth">Ciągłe kolorowanie</label></div>
-            
+
         </div>
     </div>
     <div class="flex-grow-1 flex-fill">
         <div id="map"></div>
     </div>
 </div>
-
 
 <div class="modal fade" id="coordinatesModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLongTitle"
      aria-hidden="true">
@@ -82,7 +83,12 @@
         crossorigin="anonymous"></script>
 <script src="https://d19vzq90twjlae.cloudfront.net/leaflet-0.7/leaflet.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
+
+<script src="https://unpkg.com/leaflet-geosearch@3.0.5/dist/geosearch.umd.js"></script>
+
 <script src="{% static 'map.js' %}"></script>
+
+
 
 </body>
 


### PR DESCRIPTION
After using the search bar you can't drag or zoom the map. 
```
map.on('click', function (e) {
    map.dragging.enable();
    map.touchZoom.enable();
    map.doubleClickZoom.enable();
    map.scrollWheelZoom.enable();
    map.boxZoom.enable();
    map.keyboard.enable();
});
```
in map.js fixes this, but only after clicking on the map, maybe can be solved better. 